### PR TITLE
Map phone type 'voice' to 'other'.

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -468,6 +468,8 @@ class CardDAV2FB
                   $type = "other";
                 elseif(in_array("dom", $typearr_lower))
                   $type = "other";
+                elseif(in_array("voice", $typearr_lower))
+                  $type = "other";
                 else
                   continue;
               }


### PR DESCRIPTION
vcards my contain phone entries of type voice as the standard type. So this type should not be discarded.