### PR TITLE
fix: strip quotes that may occur in type fields

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -448,6 +448,10 @@ class CardDAV2FB
                     $quickdial = $value;
                   }
                 }
+		      
+                foreach($t['type'] as $k=>$v) {
+                  $t['type'][$k] = str_replace('"','',$v);
+                }
 
                 $typearr_lower = unserialize(strtolower(serialize($t['type'])));
 


### PR DESCRIPTION
Types like `TEL;TYPE="VOICE,WORK":+12 345 6789` may occur in vcf files, but are not recognized correctly because of the `"` chars. This version fixes this. :)