### PR TITLE
Phone type mapping and PNG support

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -462,10 +462,10 @@ class CardDAV2FB
                 // set the proper type
                 if(in_array("cell", $typearr_lower))
                   $type = "mobile";
-                elseif(in_array("home", $typearr_lower))
-                  $type = "home";
                 elseif(in_array("fax", $typearr_lower))
                   $type = "fax_work";
+                elseif(in_array("home", $typearr_lower))
+                  $type = "home";
                 elseif(in_array("work", $typearr_lower))
                   $type = "work";
                 elseif(in_array("main", $typearr_lower))

--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -468,12 +468,15 @@ class CardDAV2FB
                   $type = "fax_work";
                 elseif(in_array("work", $typearr_lower))
                   $type = "work";
+                elseif(in_array("main", $typearr_lower))
+                  $type = "work";
                 elseif(in_array("other", $typearr_lower))
                   $type = "other";
                 elseif(in_array("dom", $typearr_lower))
                   $type = "other";
                 elseif(in_array("voice", $typearr_lower))
                   $type = "other";
+
                 else
                   continue;
               }


### PR DESCRIPTION
234e547: I added "main" as phone type to the mapping. It maps to "work".
84a5e1c: As soon as "fax" is identified, it makes sense to map this number to "fax_work". Even, if it would be "fax_home". But this does not exist in the Fritz!box.
3dc93b3: PNG support (by converting PNGs to JPGs with PHP functions).

